### PR TITLE
New option for recurring failed backups

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,0 +1,2 @@
+[flake8]
+max-line-length = 250

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,0 +1,23 @@
+---
+name: Lint Code Base
+# https://github.com/github/super-linter/blob/master/README.md
+# https://help.github.com/en/articles/workflow-syntax-for-github-actions
+on:
+  push:
+    branches-ignore:
+      - 'master'
+jobs:
+  build:
+    name: Lint Code Base
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v2
+      - name: Lint Code Base
+        uses: docker://github/super-linter:v2.2.0
+        env:
+          VALIDATE_PYTHON: false
+      - name: Lint Python
+        uses: docker://mvantellingen/python-lint:latest
+        with:
+          args: flake8 /github/workspace

--- a/README.md
+++ b/README.md
@@ -1,61 +1,71 @@
 # check_bareos
-Icinga Monitoring Plugin to check Bareos Backup Director databases
+Icinga Monitoring Plugin to check Bareos Backup Director databases. Usable in sensu/sensu-go
 
-Main Git Repository: https://github.com/widhalmt/check_bareos
-At the moment this is a fork repository to make it to a synchronized project with thise site.
+Main Git Repository: <https://github.com/VeselaHouba/check_bareos>
+
+At the moment this is a fork repository to make it to a synchronised project with this site.
 
 This project is mainly aimed at fixing some bugs.
 
 If you want to add features contribute in the git project or sent an email to the author or git repository owner.
 
 
-## Check Examples: 
+## Check Examples
 
 Note: use the postgresql database bareos and login without password
 
 
-#### Check if a full backup has 0 Bytes(is Empty) and trigger warning it is at least 1 and trigger ciritcal if more than 5 are empty 
-```check_bareos.py -u bareos -d p status -e -f -w 1 -c 5```
+**Check if a full backup has 0 Bytes(is Empty) and trigger warning it is at least 1 and trigger ciritcal if more than 5 are empty**
+```BASH
+check_bareos.py -u bareos -d p status -e -f -w 1 -c 5
+```
 
+**Check if a diff/inc backup is larger than 2 TB (default value) and trigger warning it is at least 1 and trigger ciritcal if more than 5 are empty**
+```BASH
+check_bareos.py -u bareos -d p status -o -d -i -w 1 -c 5
+```
 
-##### Check if a diff/inc backup is larger than 2 TB (default value) and trigger warning it is at least 1 and trigger ciritcal if more than 5 are empty 
-```check_bareos.py -u bareos -d p status -o -d -i -w 1 -c 5```
+**Check how much tapes are empty in the storage**
+```BASH
+check_bareos.py -u bareos -d p tape -e -w 15 -c 10
+```
 
+**Check total size of all backups**
+```BASH
+check_bareos.py -u bareos -d p status -b -w 400 -c 500
+```
 
-#### Check how much tapes are empty in the storage
-```check_bareos.py -u bareos -d p tape -e -w 15 -c 10```
+**Check total size of all full backups**
+```BASH
+check_bareos.py -u bareos -d p status -b -f -w 400 -c 500
+```
 
+**Check total size of all diff backups**
+```BASH
+check_bareos.py -u bareos -d p status -b -d -w 400 -c 500
+```
 
-#### Check total size of all backups
-```check_bareos.py -u bareos -d p status -b -w 400 -c 500```
+**Check total size of all inc backups**
+```BASH
+check_bareos.py -u bareos -d p status -b -i -w 400 -c 500
+```
 
+**Check if a job is runing longar than 7 days (default value)**
+```BASH
+check_bareos.py  -u bareos -d p job -rt -t 4 -st R  -w 1 -c 4
+```
 
-#### Check total size of all full backups
-```check_bareos.py -u bareos -d p status -b -f -w 400 -c 500```
+**Check how much jobs are in the wating status**
+```BASH
+check_bareos.py -u bareos -d p job  -js -w 50 -c 100
+```
 
+**Check how much tapes are expired**
+```BASH
+check_bareos.py -u bareos -d p tape -ex
+```
 
-#### Check total size of all diff backups
-```check_bareos.py -u bareos -d p status -b -d -w 400 -c 500```
-
-
-#### Check total size of all inc backups
-```check_bareos.py -u bareos -d p status -b -i -w 400 -c 500```
-
-
-#### Check if a job is runing longar than 7 days (default value)
-```check_bareos.py  -u bareos -d p job -rt -t 4 -st R  -w 1 -c 4```
-
-
-#### Check how much jobs are in the wating status
-```check_bareos.py -u bareos -d p job  -js -w 50 -c 100```
-
-
-#### Check how much tapes are expired
-```check_bareos.py -u bareos -d p tape -ex```
-
-
-#### Check how much tapes will expire in the next 14 days
-```check_bareos.py -u bareos -d p tape -wex -t 14 -w 10 -c 5```
-
- 
-
+**Check how much tapes will expire in the next 14 days**
+```BASH
+check_bareos.py -u bareos -d p tape -wex -t 14 -w 10 -c 5
+```

--- a/check_bareos.py
+++ b/check_bareos.py
@@ -136,10 +136,11 @@ def checkRecurringFailedBackups(courser, time, warning, critical):
             failed_level = failed[1]
             failed_starttime = failed[2]
             # Check if newer successful job exists for the failed jobname
+            # status = Finished, Running, Queued
             query = """
             SELECT Job.Name,Level,starttime,JobStatus
             FROM Job
-            Where Job.Name = '""" + str(failed_jobname) + """' and JobStatus in ('T')
+            Where Job.Name = '""" + str(failed_jobname) + """' and JobStatus in ('T','R','A')
             and Job.starttime > '""" + str(failed_starttime) + """'
             and Job.Level = '""" + str(failed_level) + """';
             """
@@ -150,7 +151,7 @@ def checkRecurringFailedBackups(courser, time, warning, critical):
                 failed_jobs_not_fixed += failed_jobname + "; "
         if failed_jobs_not_fixed == "":
             checkState["returnCode"] = 0
-            checkState["returnMessage"] = "OK - Some jobs failed, but new successful exists for the same jobs in the last " + str(time) + " days"
+            checkState["returnMessage"] = "OK - Some jobs failed, but new job exists for the same jobs in the last " + str(time) + " days"
         else:
             checkState["returnCode"] = 2
             checkState["returnMessage"] = "CRITICAL - " + str(result) + " Backups failed/canceled last " + str(time) + " days: " + failed_jobs_not_fixed


### PR DESCRIPTION
New switch `-rfb` will check list of failed backups. 
For every failed backup, it will check if there's some more recent backup of same type which finished successfully. Then return OK.
Otherwise critical.

Use cases:
1. You don't miss recurring failed backups for single host, if the total failed backup number is under threshold.
1. Backup fails, triggers alarm, administrator fixes issue and re-runs backup. Consequent successful backup will silent the monitoring.