### PR TITLE
Fix wrong query in checkruntimejobs

### DIFF
--- a/check_bareos.py
+++ b/check_bareos.py
@@ -388,7 +388,7 @@ def checkRunTimeJobs(cursor, state, time, warning, critical):
     query = """
     SELECT Count(Job.Name)
     FROM Job
-    WHERE starttime < (now()::date-""" + str(time) + """ * '1 day'::INTERVAL) AND Job.JobStatus like '""" + state + """';
+    WHERE starttime < (now()::date-""" + str(time) + """ * '1 day'::INTERVAL) AND Job.JobStatus in (""" + state + """);
     """
 
     cursor.execute(query)
@@ -405,7 +405,7 @@ def checkRunTimeJobs(cursor, state, time, warning, critical):
         checkState["returnCode"] = OK
         checkState["returnMessage"] = "[OK]"
 
-    checkState["returnMessage"] += " - " + str(result) + " Jobs are running longer than " + str(time) + " days"
+    checkState["returnMessage"] += " - " + str(result) + " Jobs in state " + state.replace("'", "") + " are running longer than " + str(time) + " days"
 
     checkState["performanceData"] = "bareos.job.count=" + str(result) + ";" + str(warning) + ";" + str(critical) + ";;"
 

--- a/test_check_bareos.py
+++ b/test_check_bareos.py
@@ -191,14 +191,15 @@ class SQLTesting(unittest.TestCase):
 
         c.fetchone.return_value = [2]
         actual = checkRunTimeJobs(c, "'F','I','D'", 1, Threshold(3), Threshold(5))
-        expected = {'returnCode': 0, 'returnMessage': '[OK] - 2.0 Jobs are running longer than 1 days', 'performanceData': 'bareos.job.count=2.0;3;5;;'}
+        c.execute.assert_called_with("\n    SELECT Count(Job.Name)\n    FROM Job\n    WHERE starttime < (now()::date-1 * '1 day'::INTERVAL) AND Job.JobStatus in ('F','I','D');\n    ")
+
+        expected = {'returnCode': 0, 'returnMessage': '[OK] - 2.0 Jobs in state F,I,D are running longer than 1 days', 'performanceData': 'bareos.job.count=2.0;3;5;;'}
         self.assertEqual(actual, expected)
 
         c.fetchone.return_value = [10]
         actual = checkRunTimeJobs(c, "'F','I','D'", 1, Threshold(3), Threshold(5))
-        expected = {'returnCode': 2, 'returnMessage': '[CRITICAL] - 10.0 Jobs are running longer than 1 days', 'performanceData': 'bareos.job.count=10.0;3;5;;'}
+        expected = {'returnCode': 2, 'returnMessage': '[CRITICAL] - 10.0 Jobs in state F,I,D are running longer than 1 days', 'performanceData': 'bareos.job.count=10.0;3;5;;'}
         self.assertEqual(actual, expected)
-
 
     def test_checkEmptyBackups(self):
 


### PR DESCRIPTION
 - The query assumed a string and used LIKE, probably from an older iteration of the plugin. Now uses IN syntax to support multiple states

Fixes #40 